### PR TITLE
Feature/dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
     <dropwizard.version>2.0.24</dropwizard.version>
-    <foundationdb.version>6.3.1</foundationdb.version>
-    <record-layer.version>2.8.91.0</record-layer.version>
+    <foundationdb.version>6.3.17</foundationdb.version>
+    <record-layer.version>2.8.110.0</record-layer.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/io/dropwizard/foundationdb/FoundationDBFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/FoundationDBFactory.java
@@ -12,7 +12,7 @@ import io.dropwizard.foundationdb.managed.FoundationDBManager;
 import io.dropwizard.foundationdb.security.SecurityFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.util.Duration;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/dropwizard/foundationdb/FoundationDBFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/FoundationDBFactory.java
@@ -12,7 +12,6 @@ import io.dropwizard.foundationdb.managed.FoundationDBManager;
 import io.dropwizard.foundationdb.security.SecurityFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.util.Duration;
-import javax.validation.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +21,7 @@ import java.util.concurrent.Executor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 /**

--- a/src/main/java/io/dropwizard/foundationdb/RecordLayerFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/RecordLayerFactory.java
@@ -15,7 +15,7 @@ import io.dropwizard.foundationdb.managed.RecordLayerManager;
 import io.dropwizard.foundationdb.security.SecurityFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.util.Duration;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/io/dropwizard/foundationdb/RecordLayerFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/RecordLayerFactory.java
@@ -15,7 +15,6 @@ import io.dropwizard.foundationdb.managed.RecordLayerManager;
 import io.dropwizard.foundationdb.security.SecurityFactory;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.util.Duration;
-import javax.validation.constraints.NotEmpty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +24,7 @@ import java.util.concurrent.Executor;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 public class RecordLayerFactory {

--- a/src/main/java/io/dropwizard/foundationdb/instrumented/InstrumentedDatabase.java
+++ b/src/main/java/io/dropwizard/foundationdb/instrumented/InstrumentedDatabase.java
@@ -2,6 +2,7 @@ package io.dropwizard.foundationdb.instrumented;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.DatabaseOptions;
+import com.apple.foundationdb.EventKeeper;
 import com.apple.foundationdb.ReadTransaction;
 import com.apple.foundationdb.Transaction;
 
@@ -41,6 +42,11 @@ public class InstrumentedDatabase implements Database {
     @Override
     public Transaction createTransaction(final Executor e) {
         return database.createTransaction(e);
+    }
+
+    @Override
+    public Transaction createTransaction(final Executor e, final EventKeeper ek) {
+        return database.createTransaction(e, ek);
     }
 
     @Override

--- a/src/main/java/io/dropwizard/foundationdb/security/MultipleFileSecurityFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/security/MultipleFileSecurityFactory.java
@@ -4,8 +4,8 @@ import com.apple.foundationdb.NetworkOptions;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @JsonTypeName("multi-file")

--- a/src/main/java/io/dropwizard/foundationdb/security/SecurityFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/security/SecurityFactory.java
@@ -5,6 +5,7 @@ import com.apple.foundationdb.NetworkOptions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
+
 import javax.validation.constraints.NotEmpty;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")

--- a/src/main/java/io/dropwizard/foundationdb/security/SecurityFactory.java
+++ b/src/main/java/io/dropwizard/foundationdb/security/SecurityFactory.java
@@ -5,7 +5,7 @@ import com.apple.foundationdb.NetworkOptions;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.dropwizard.jackson.Discoverable;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public abstract class SecurityFactory implements Discoverable {

--- a/src/test/java/io/dropwizard/foundationdb/health/FoundationDBHealthCheckTest.java
+++ b/src/test/java/io/dropwizard/foundationdb/health/FoundationDBHealthCheckTest.java
@@ -32,6 +32,7 @@ public class FoundationDBHealthCheckTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldReturnHealthyIfValidationSucceeds() {
         when(mockedDatabase.read(any())).thenReturn(mockedFuture);
 
@@ -42,6 +43,7 @@ public class FoundationDBHealthCheckTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void shouldReturnUnhealthyIfValidationFails() {
         when(mockedDatabase.read(any(Function.class))).thenThrow(new FDBException("something bad", 1234));
 


### PR DESCRIPTION
- Dependency upgrade for FoundationDB
- Fix dependency upgrade by adding support for `createTransaction(Executor, EventKeeper)`
- Replace deprecated annotation `@NotEmpty` from hibernate
- Suppress unchecked warning for testing