### PR TITLE
Remove maven-failsafe-plugin from pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,6 @@
   </dependencies>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.5</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
maven-failsafe-plugin is managed via `io.dropwizard.modules:module-parent`.